### PR TITLE
createElement with compiler changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "version": "17.0.2",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/packages/react/index.stable.js
+++ b/packages/react/index.stable.js
@@ -31,6 +31,7 @@ export {
   StrictMode,
   Suspense,
   createElement,
+  createFastElement,
   cloneElement,
   isValidElement,
   version,

--- a/packages/react/index.stable.js
+++ b/packages/react/index.stable.js
@@ -31,7 +31,7 @@ export {
   StrictMode,
   Suspense,
   createElement,
-  createFastElement,
+  f,
   cloneElement,
   isValidElement,
   version,

--- a/packages/react/src/React.js
+++ b/packages/react/src/React.js
@@ -24,6 +24,7 @@ import {createRef} from './ReactCreateRef';
 import {forEach, map, count, toArray, only} from './ReactChildren';
 import {
   createElement as createElementProd,
+  createFastElement as createFastElementProd,
   createFactory as createFactoryProd,
   cloneElement as cloneElementProd,
   isValidElement,
@@ -61,6 +62,8 @@ import {startTransition} from './ReactStartTransition';
 
 // TODO: Move this branching into the other module instead and just re-export.
 const createElement = __DEV__ ? createElementWithValidation : createElementProd;
+const createFastElement = __DEV__ ? createElementWithValidation : createFastElementProd;
+
 const cloneElement = __DEV__ ? cloneElementWithValidation : cloneElementProd;
 const createFactory = __DEV__ ? createFactoryWithValidation : createFactoryProd;
 
@@ -99,6 +102,7 @@ export {
   REACT_DEBUG_TRACING_MODE_TYPE as unstable_DebugTracingMode,
   REACT_SUSPENSE_TYPE as Suspense,
   createElement,
+  createFastElement,
   cloneElement,
   isValidElement,
   ReactVersion as version,

--- a/packages/react/src/React.js
+++ b/packages/react/src/React.js
@@ -24,7 +24,7 @@ import {createRef} from './ReactCreateRef';
 import {forEach, map, count, toArray, only} from './ReactChildren';
 import {
   createElement as createElementProd,
-  createFastElement as createFastElementProd,
+  f as fProd,
   createFactory as createFactoryProd,
   cloneElement as cloneElementProd,
   isValidElement,
@@ -62,7 +62,7 @@ import {startTransition} from './ReactStartTransition';
 
 // TODO: Move this branching into the other module instead and just re-export.
 const createElement = __DEV__ ? createElementWithValidation : createElementProd;
-const createFastElement = __DEV__ ? createElementWithValidation : createFastElementProd;
+const f = __DEV__ ? createElementWithValidation : fProd;
 
 const cloneElement = __DEV__ ? cloneElementWithValidation : cloneElementProd;
 const createFactory = __DEV__ ? createFactoryWithValidation : createFactoryProd;
@@ -102,7 +102,7 @@ export {
   REACT_DEBUG_TRACING_MODE_TYPE as unstable_DebugTracingMode,
   REACT_SUSPENSE_TYPE as Suspense,
   createElement,
-  createFastElement,
+  f,
   cloneElement,
   isValidElement,
   ReactVersion as version,

--- a/packages/react/src/ReactElement.js
+++ b/packages/react/src/ReactElement.js
@@ -341,6 +341,100 @@ export function jsxDEV(type, config, maybeKey, source, self) {
   );
 }
 
+export function createFastElement(type, config, children) {
+  let propName;
+
+  // Reserved names are extracted
+  let props = config;
+
+  let key = null;
+  let ref = null;
+  let self = null;
+  let source = null;
+
+  if (props != null) {
+    if (hasValidRef(props)) {
+      ref = props.ref;
+
+      if (__DEV__) {
+        warnIfStringRefCannotBeAutoConverted(props);
+      }
+    }
+    if (hasValidKey(props)) {
+      key = '' + props.key;
+    }
+
+    self = props.__self === undefined ? null : props.__self;
+    source = props.__source === undefined ? null : props.__source;
+
+    let shouldRecomputeProps = false;
+
+    for (propName in RESERVED_PROPS) {
+      if (hasOwnProperty.call(props, propName)) {
+        shouldRecomputeProps = true;
+      }
+    }
+
+    if (shouldRecomputeProps) {
+      // eslint-disable-next-line no-unused-vars
+      const {key: _key, ref: _ref, __source, __self, ...rest} = props;
+
+      props = rest;
+    }
+  }
+
+  // Children can be more than one argument, and those are transferred onto
+  // the newly allocated props object.
+  const childrenLength = arguments.length - 2;
+  if (childrenLength === 1) {
+    props.children = children;
+  } else if (childrenLength > 1) {
+    const childArray = Array(childrenLength);
+    for (let i = 0; i < childrenLength; i++) {
+      childArray[i] = arguments[i + 2];
+    }
+    if (__DEV__) {
+      if (Object.freeze) {
+        Object.freeze(childArray);
+      }
+    }
+    props.children = childArray;
+  }
+
+  // Resolve default props
+  if (type && type.defaultProps) {
+    const defaultProps = type.defaultProps;
+    for (propName in defaultProps) {
+      if (props[propName] === undefined) {
+        props[propName] = defaultProps[propName];
+      }
+    }
+  }
+  if (__DEV__) {
+    if (key || ref) {
+      const displayName =
+        typeof type === 'function'
+          ? type.displayName || type.name || 'Unknown'
+          : type;
+      if (key) {
+        defineKeyPropWarningGetter(props, displayName);
+      }
+      if (ref) {
+        defineRefPropWarningGetter(props, displayName);
+      }
+    }
+  }
+  return ReactElement(
+    type,
+    key,
+    ref,
+    self,
+    source,
+    ReactCurrentOwner.current,
+    props,
+  );
+}
+
 /**
  * Create and return a new ReactElement of the given type.
  * See https://reactjs.org/docs/react-api.html#createelement

--- a/packages/react/src/ReactElement.js
+++ b/packages/react/src/ReactElement.js
@@ -341,7 +341,7 @@ export function jsxDEV(type, config, maybeKey, source, self) {
   );
 }
 
-export function createFastElement(type, config, children) {
+export function f(type, config, children) {
   let propName;
 
   // Reserved names are extracted

--- a/scripts/rollup/build.js
+++ b/scripts/rollup/build.js
@@ -100,8 +100,8 @@ const errorCodeOpts = {
 
 const closureOptions = {
   compilation_level: 'SIMPLE',
-  language_in: 'ECMASCRIPT_2015',
-  language_out: 'ECMASCRIPT5_STRICT',
+  language_in: 'ECMASCRIPT_2020',
+  language_out: 'ECMASCRIPT_2020',
   env: 'CUSTOM',
   warning_level: 'QUIET',
   apply_input_source_maps: false,
@@ -117,20 +117,12 @@ const babelPlugins = [
   '@babel/plugin-transform-flow-strip-types',
   ['@babel/plugin-proposal-class-properties', {loose: true}],
   'syntax-trailing-function-commas',
-  // These use loose mode which avoids embedding a runtime.
-  // TODO: Remove object spread from the source. Prefer Object.assign instead.
-  [
-    '@babel/plugin-proposal-object-rest-spread',
-    {loose: true, useBuiltIns: true},
-  ],
   ['@babel/plugin-transform-template-literals', {loose: true}],
   // TODO: Remove for...of from the source. It requires a runtime to be embedded.
   '@babel/plugin-transform-for-of',
   // TODO: Remove array spread from the source. Prefer .apply instead.
   ['@babel/plugin-transform-spread', {loose: true, useBuiltIns: true}],
   '@babel/plugin-transform-parameters',
-  // TODO: Remove array destructuring from the source. Requires runtime.
-  ['@babel/plugin-transform-destructuring', {loose: true, useBuiltIns: true}],
 ];
 
 const babelToES5Plugins = [


### PR DESCRIPTION
To apply this patch:

1. Run `yarn`
2. Run `$env:RELEASE_CHANNEL = "stable"; yarn build`
3. Copy `build\node_modules\react\cjs\react.production.min.js` into your own repositories `node_modules\react\cjs\react.production.min.js`
4. Run `npx patch-package react` in your own repository root folder.